### PR TITLE
fix failing builds

### DIFF
--- a/scripts/create_commit.sh
+++ b/scripts/create_commit.sh
@@ -33,9 +33,11 @@ git config --global user.name "shiptest-github-owner" 2>&1
 
 add_ssh_key
 
+rm -rf $PROJ_NAME || true
+
 echo "######### cloning repo #########"
 git clone git@github.com:$ORG_NAME/$PROJ_NAME 2>&1
-cd $PROJ_NAME
+pushd $PROJ_NAME
 
 if [ -z $BRANCH_NAME ]; then
   echo 'using default branch master'
@@ -55,4 +57,5 @@ git commit -m "dummy commit $(date +%Y-%m-%d-%H-%M-%S)" 2>&1
 echo "########### pushing to branch: $BRANCH_NAME ##########"
 git push -f origin $BRANCH_NAME 2>&1
 
+popd
 rm -rf $PROJ_NAME 2>&1

--- a/scripts/create_tag.sh
+++ b/scripts/create_tag.sh
@@ -37,9 +37,11 @@ git config --global user.name "shiptest-github-owner" 2>&1
 
 add_ssh_key
 
+rm -rf $PROJ_NAME || true
+
 echo "######### cloning repo #########"
 git clone git@github.com:$ORG_NAME/$PROJ_NAME 2>&1
-cd $PROJ_NAME
+pushd $PROJ_NAME
 
 echo "############ create tag ############"
 git tag $TAG_NAME 2>&1
@@ -47,4 +49,5 @@ git tag $TAG_NAME 2>&1
 echo "########### pushing to git ##########"
 git push origin --tags 2>&1
 
+popd
 rm -rf $PROJ_NAME

--- a/tests/core/skippable/GHC-ORG-PRI-TAG-ADM.js
+++ b/tests/core/skippable/GHC-ORG-PRI-TAG-ADM.js
@@ -166,7 +166,7 @@ describe(testSuite + testSuiteDesc,
         initialDelay: 1000, // ms
         maxDelay: 2000 // max retry interval of 2 second
       });
-      expBackoff.failAfter(15); // fail after 15 attempts(30 sec)
+      expBackoff.failAfter(60); // fail after 60 attempts
       expBackoff.on('backoff',
         function (number, delay) {
           logger.info('No tag build for project with id:', projectId, 'yet.',

--- a/tests/core/skippable/GHC-ORG-PRI-TAG-COL.js
+++ b/tests/core/skippable/GHC-ORG-PRI-TAG-COL.js
@@ -166,7 +166,7 @@ describe(testSuite + testSuiteDesc,
         initialDelay: 1000, // ms
         maxDelay: 2000 // max retry interval of 2 second
       });
-      expBackoff.failAfter(15); // fail after 15 attempts(30 sec)
+      expBackoff.failAfter(60); // fail after 60 attempts
       expBackoff.on('backoff',
         function (number, delay) {
           logger.info('No tag build for project with id:', projectId, 'yet.',

--- a/tests/core/skippable/GHC-ORG-PUB-TAG-ADM.js
+++ b/tests/core/skippable/GHC-ORG-PUB-TAG-ADM.js
@@ -166,7 +166,7 @@ describe(testSuite + testSuiteDesc,
         initialDelay: 1000, // ms
         maxDelay: 2000 // max retry interval of 2 second
       });
-      expBackoff.failAfter(15); // fail after 15 attempts(30 sec)
+      expBackoff.failAfter(60); // fail after 60 attempts
       expBackoff.on('backoff',
         function (number, delay) {
           logger.info('No tag build for project with id:', projectId, 'yet.',

--- a/tests/core/skippable/GHC-ORG-PUB-TAG-COL.js
+++ b/tests/core/skippable/GHC-ORG-PUB-TAG-COL.js
@@ -166,7 +166,7 @@ describe(testSuite + testSuiteDesc,
         initialDelay: 1000, // ms
         maxDelay: 2000 // max retry interval of 2 second
       });
-      expBackoff.failAfter(15); // fail after 15 attempts(30 sec)
+      expBackoff.failAfter(60); // fail after 60 attempts
       expBackoff.on('backoff',
         function (number, delay) {
           logger.info('No tag build for project with id:', projectId, 'yet.',


### PR DESCRIPTION
fixes failing bvt builds

1) increase timeout for tag builds
2)  fix scripts for generating tags and commits. delete older repo first. 